### PR TITLE
feat: `--ratio()` - the ratio between two values

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -2,7 +2,7 @@
 
 Complete reference for all CSS custom functions in css-extras.
 
-**Total functions:** 35
+**Total functions:** 36
 
 ---
 
@@ -88,6 +88,27 @@ Maps a value from one range to another.
 
 ```css
 font-size: --map-range(50vw, 320px, 1920px, 14px, 24px);
+```
+
+---
+
+## `--ratio()`
+
+Return the ratio of the first value to the second value.
+
+### Parameters
+
+- **`--value`** (`CalcSum`): Input value.
+- **`--to-value`** (`CalcSum`): Another input value.
+
+### Returns
+
+`Number`: The ratio between two values.
+
+### Example
+
+```css
+scale: --ratio(16px, 1em);
 ```
 
 ---

--- a/index.css
+++ b/index.css
@@ -61,7 +61,7 @@ Maps a value from one range to another.
 }
 
 /**
-Return the ratio of the first value to the second value.
+Returns the ratio of two values. Supports values with different units, unlike regular division.
 
 @param {CalcSum} --value - Input value.
 @param {CalcSum} --to-value - Another input value.

--- a/index.css
+++ b/index.css
@@ -60,6 +60,18 @@ Maps a value from one range to another.
 	result: calc(var(--out-min) + (var(--out-max) - var(--out-min)) * var(--progress));
 }
 
+/**
+Return the ratio of the first value to the second value.
+
+@param {CalcSum} --value - Input value.
+@param {CalcSum} --to-value - Another input value.
+@returns {Number} The ratio between two values.
+@example scale: --ratio(16px, 1em);
+*/
+@function --ratio(--value, --to-value) {
+	result: tan(atan2(var(--value), var(--to-value)));
+}
+
 /* ===================================
 	 Color Functions
 	 =================================== */

--- a/readme.md
+++ b/readme.md
@@ -57,9 +57,9 @@ Then use any of the functions in your CSS:
 
 ## Functions
 
-This package includes 35 CSS custom functions organized into these categories:
+This package includes 36 CSS custom functions organized into these categories:
 
-- **Math & Number** - `--negate()`, `--abs()`, `--lerp()`, `--map-range()`
+- **Math & Number** - `--negate()`, `--abs()`, `--lerp()`, `--map-range()`, `--ratio()`
 - **Color** - `--opacity()`, `--tint()`, `--shade()`, `--saturate()`, `--lighten()`, `--rotate-hue()`, `--complement()`, `--invert()`, `--black()`, `--white()`
 - **Typography** - `--fluid-type()`, `--modular-scale()`, `--line-height-length()`, `--line-height-ratio()`, `--line-height-unitless()`
 - **Layout** - `--sidebar-layout()`, `--conditional-radius()`, `--responsive-value()`, `--aspect-height()`

--- a/test-runner.js
+++ b/test-runner.js
@@ -51,6 +51,24 @@ const tests = [
 		property: '--test-map-range',
 		expected: 'calc(0px + (200px - 0px) * clamp(0, calc((50 - 0) / (100 - 0)), 1))',
 	},
+	{
+		name: '--ratio(8px * 2, 0.55em + 0.45em)',
+		selector: '.test-math',
+		property: '--test-ratio-dimension',
+		expected: 'tan(atan2(8px * 2, 0.55em + 0.45em))',
+	},
+	{
+		name: '--ratio(8 * 2, 5.5 + 4.5)',
+		selector: '.test-math',
+		property: '--test-ratio-number',
+		expected: 'tan(atan2(8 * 2, 5.5 + 4.5))',
+	},
+	{
+		name: '--ratio(80% * 2, 55% + 45%)',
+		selector: '.test-math',
+		property: '--test-ratio-percentage',
+		expected: 'tan(atan2(80% * 2, 55% + 45%))',
+	},
 
 	// Color tests
 	{

--- a/test-visual.html
+++ b/test-visual.html
@@ -121,6 +121,26 @@
 			background: var(--warning);
 		}
 
+		.demo-ratio {
+			width: 200px;
+			height: 30px;
+			background: var(--error);
+			container-type: size;
+			
+			&::after {
+				scale: --ratio(100cqw, 20px) 1;
+				transform-origin: left;
+				content: "a";
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				color: white;
+				width: 20px;
+				height: 100%;
+				background: var(--success);
+			}
+		}
+
 		/* Color function demos */
 		.demo-colors {
 			display: grid;
@@ -397,6 +417,11 @@
 				<div class="test-label">--lerp(100px, 300px, 0.5)</div>
 				<div class="demo-lerp"></div>
 				<div class="test-value">Width: 200px</div>
+			</div>
+			<div class="test-item">
+				<div class="test-label">--ratio(100cqw, 20px)</div>
+				<div class="demo-ratio"></div>
+				<div class="test-value">Scale: 10 1</div>
 			</div>
 		</div>
 	</section>

--- a/test.css
+++ b/test.css
@@ -37,6 +37,12 @@
 	--test-map-range: --map-range(50, 0, 100, 0px, 200px); /* Expected: 100px */
 	--test-map-range-min: --map-range(0, 0, 100, 10px, 20px); /* Expected: 10px */
 	--test-map-range-max: --map-range(100, 0, 100, 10px, 20px); /* Expected: 20px */
+
+	/* --ratio() tests */
+	font-size: 10px;
+	--test-ratio-dimension: --ratio(8px * 2, 0.55em + 0.45em); /* Expected: 1.6 */
+	--test-ratio-number: --ratio(8 * 2, 5.5 + 4.5); /* Expected: 1.6 */
+	--test-ratio-percentage: --ratio(80% * 2, 55% + 45%); /* Expected: 1.6 */
 }
 
 /* ===================================


### PR DESCRIPTION
This PR adds a function that calculates the proportion of two values (`<length>`/`<angle>`/`<percentage>`/`<number>`). `calc(<value1> / <value2>)` cannot achieve this because it requires the right operand to be unitless. This function can be used anywhere that accepts a `<number>` type, even inside `calc()`s.

Its functionality has a real-world use case. On a MediaWiki site, I used `transform: scale(tan(atan2(<display_size>, <viewBox_size>)));` to achieve functionality similar to SVG's `viewBox`. The `tan(atan2(<value1>, <value2>))` is exactly what `--proportion()` function in this PR does.

```html
<span style="
  display: inline-block;
  position: relative;
  overflow: hidden;
  height: 1em;
  width: 1em;
">
  <span style="
    display: block;
    position: absolute;
    width: 24px;
    height: 24px;
    transform-origin: left top;
    transform: scale(tan(atan2(1em, 24px))); /* here */
    background: currentColor;
    clip-path: path('M15 4l6 2v5h-3v8a1 1 0 0 1 -1 1h-10a1 1 0 0 1 -1 -1v-8h-3v-5l6 -2a3 3 0 0 0 6 0');
  "></span>
</span>
```