### PR TITLE
Add example outputs to functions doc

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -22,6 +22,7 @@ Negates a value (returns the negative).
 
 ```css
 padding: --negate(1em);
+/* Output: padding: -1em; */
 ```
 
 ---
@@ -44,6 +45,7 @@ Linear interpolation between two values.
 
 ```css
 width: --lerp(100px, 200px, 0.5);
+/* Output: width: 150px; */
 ```
 
 ---
@@ -68,6 +70,7 @@ Maps a value from one range to another.
 
 ```css
 font-size: --map-range(50vw, 320px, 1920px, 14px, 24px);
+/* Output: Scales font from 14px at 320px viewport to 24px at 1920px viewport */
 ```
 
 ---
@@ -89,6 +92,7 @@ Returns the ratio of two values. Supports values with different units, unlike re
 
 ```css
 scale: --ratio(16px, 1em);
+/* Output: scale: 1; (assuming 1em = 16px) */
 ```
 
 ---
@@ -110,6 +114,7 @@ Returns a semi-transparent version of any color.
 
 ```css
 background: --opacity(blue, 50%);
+/* Output: background: rgb(0 0 255 / 0.5); */
 ```
 
 ---
@@ -132,6 +137,7 @@ Uses OKLab color space for perceptually uniform mixing.
 
 ```css
 background: --tint(blue, 20%);
+/* Output: background: oklab(0.532 -0.08 -0.192); (lighter blue) */
 ```
 
 ---
@@ -154,6 +160,7 @@ Uses OKLab color space for perceptually uniform mixing.
 
 ```css
 background: --shade(blue, 20%);
+/* Output: background: oklab(0.372 -0.08 -0.192); (darker blue) */
 ```
 
 ---
@@ -176,6 +183,7 @@ Uses OKLCH color space for perceptually uniform chroma adjustment. Chroma is cla
 
 ```css
 color: --saturate(red, 1.5);
+/* Output: color: oklch(0.628 0.4 29.234); (more saturated red) */
 ```
 
 ---
@@ -198,6 +206,7 @@ Uses OKLCH color space for perceptually uniform lightness adjustment. Maintains 
 
 ```css
 background: --lighten(blue, 20%);
+/* Output: background: oklch(0.652 0.24 264.052); (lighter blue) */
 ```
 
 ---
@@ -220,6 +229,7 @@ Uses OKLCH color space for perceptually uniform lightness adjustment. Unlike `--
 
 ```css
 background: --darken(blue, 20%);
+/* Output: background: oklch(0.252 0.24 264.052); (darker blue) */
 ```
 
 ---
@@ -242,6 +252,7 @@ Uses OKLCH color space for perceptually uniform hue rotation.
 
 ```css
 background: --rotate-hue(blue, 180deg);
+/* Output: background: oklch(0.452 0.24 84.052); (yellow-green) */
 ```
 
 ---
@@ -263,6 +274,7 @@ Uses OKLCH color space for perceptually accurate complementary colors.
 
 ```css
 border-color: --complement(blue);
+/* Output: border-color: oklch(0.452 0.24 84.052); (yellow-orange complement) */
 ```
 
 ---
@@ -283,6 +295,7 @@ Inverts a color.
 
 ```css
 background: --invert(white);
+/* Output: background: rgb(0 0 0); (black) */
 ```
 
 ---
@@ -304,6 +317,7 @@ Uses OKLCH color space by setting chroma to 0.
 
 ```css
 filter: --grayscale(var(--brand-color));
+/* Output: filter: oklch(0.452 0 264.052); (gray with same lightness) */
 ```
 
 ---
@@ -324,6 +338,7 @@ Returns black or white text color for optimal contrast on a background.
 
 ```css
 color: --text-on(var(--bg-color));
+/* Output: color: black; (or white, depending on background lightness) */
 ```
 
 ---
@@ -344,6 +359,7 @@ Removes transparency from a color, making it fully opaque.
 
 ```css
 background: --opaque(var(--semi-transparent-bg));
+/* Output: background: rgb(0 0 255); (removes alpha channel) */
 ```
 
 ---
@@ -367,6 +383,7 @@ Uses perceptually uniform OKLab color space for natural-looking color mixing.
 
 ```css
 background: --mix(red, blue, 30%);
+/* Output: background: oklab(0.537 0.126 -0.058); (reddish-purple) */
 ```
 
 ---
@@ -389,6 +406,7 @@ Triadic colors are evenly spaced around the color wheel (120° apart).
 
 ```css
 color: --triadic(blue, 1);
+/* Output: color: oklch(0.452 0.24 144.052); (120° rotation, green) */
 ```
 
 ---
@@ -411,6 +429,7 @@ Tetradic colors are evenly spaced around the color wheel (90° apart).
 
 ```css
 color: --tetradic(blue, 2);
+/* Output: color: oklch(0.452 0.24 174.052); (180° rotation, yellow-orange) */
 ```
 
 ---
@@ -431,6 +450,7 @@ Creates a semi-transparent black.
 
 ```css
 box-shadow: 0 2px 4px --black(20%);
+/* Output: box-shadow: 0 2px 4px rgb(0 0 0 / 0.2); */
 ```
 
 ---
@@ -451,6 +471,7 @@ Creates a semi-transparent white.
 
 ```css
 background: --white(90%);
+/* Output: background: rgb(255 255 255 / 0.9); */
 ```
 
 ---
@@ -475,6 +496,7 @@ NOTE: This function is mathematically equivalent to `--responsive-value()` but o
 
 ```css
 font-size: --fluid-type(16px, 24px, 320px, 1280px);
+/* Output: Scales from 16px at 320px viewport to 24px at 1280px viewport */
 ```
 
 ---
@@ -497,6 +519,7 @@ Creates a modular scale value.
 
 ```css
 font-size: --modular-scale(1rem, 1.25, 3);
+/* Output: font-size: 1.953rem; (1rem × 1.25³) */
 ```
 
 ---
@@ -519,6 +542,7 @@ Returns a length (e.g., 24px) rather than a unitless ratio. Use this when you ne
 
 ```css
 line-height: --line-height-length(16px, 1.6);
+/* Output: line-height: 25.6px; */
 ```
 
 ---
@@ -541,6 +565,7 @@ Returns a number (e.g., 1.5) which is recommended for better inheritance in CSS.
 
 ```css
 line-height: --line-height-ratio(24px, 16px);
+/* Output: line-height: 1.5; */
 ```
 
 ---
@@ -563,6 +588,7 @@ NOTE: Only works correctly with pixel font sizes. For rem/em values, use `--line
 
 ```css
 line-height: --line-height-unitless(16px, 1.5);
+/* Output: line-height: 1.5; */
 ```
 
 ---
@@ -584,6 +610,7 @@ Creates responsive sidebar layout columns.
 
 ```css
 grid-template-columns: --sidebar-layout(250px, 20ch);
+/* Output: grid-template-columns: 250px 1fr; (or stacks when content < 20ch) */
 ```
 
 ---
@@ -605,6 +632,7 @@ Conditional border radius that removes at viewport edges.
 
 ```css
 border-radius: --conditional-radius(1rem, 8px);
+/* Output: border-radius: 1rem; (0 when within 8px of viewport edge) */
 ```
 
 ---
@@ -629,6 +657,7 @@ NOTE: This function is mathematically equivalent to `--fluid-type()` but uses a 
 
 ```css
 padding: --responsive-value(1rem, 2rem, 320px, 1200px);
+/* Output: Scales from 1rem at 320px viewport to 2rem at 1200px viewport */
 ```
 
 ---
@@ -651,6 +680,7 @@ Calculates height from aspect ratio and maximum constraints.
 
 ```css
 height: --aspect-height(16/9, 100vw, 100vh);
+/* Output: height: 56.25vw; (maintains 16:9 ratio within constraints) */
 ```
 
 ---
@@ -673,6 +703,7 @@ Calculates width from aspect ratio and maximum constraints.
 
 ```css
 width: --aspect-width(16/9, 100vh, 100vw);
+/* Output: width: 177.78vh; (maintains 16:9 ratio within constraints) */
 ```
 
 ---
@@ -695,6 +726,7 @@ Recommended range: 0-10. Higher values create exponentially larger spacing.
 
 ```css
 margin: --spacing(3);
+/* Output: margin: 0.75rem; (0.25rem × 3) */
 ```
 
 ---
@@ -716,6 +748,7 @@ Creates inset spacing for containers.
 
 ```css
 padding: --container-padding(2rem, 1200px);
+/* Output: padding: calc((100% - 1200px) / 2 + 2rem); (responsive padding) */
 ```
 
 ---
@@ -736,6 +769,7 @@ Creates a simple easing curve value.
 
 ```css
 transform: translateY(--ease-out(var(--progress)));
+/* Output: Eased value between 0 and 1 with ease-out timing */
 ```
 
 ---
@@ -757,6 +791,7 @@ Creates elastic easing.
 
 ```css
 transform: scale(--elastic-ease(var(--progress), 1.2));
+/* Output: Eased value with elastic bounce effect */
 ```
 
 ---
@@ -778,6 +813,7 @@ Converts pixels to rem.
 
 ```css
 font-size: --px-to-rem(24px);
+/* Output: font-size: 1.5rem; (assuming 16px base) */
 ```
 
 ---
@@ -799,6 +835,7 @@ Converts rem to pixels.
 
 ```css
 width: --rem-to-px(2rem);
+/* Output: width: 32px; (assuming 16px base) */
 ```
 
 ---
@@ -820,6 +857,7 @@ Creates responsive grid columns.
 
 ```css
 grid-template-columns: --auto-grid(250px, 4);
+/* Output: grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); */
 ```
 
 ---
@@ -842,6 +880,7 @@ Ensures the span is an integer value.
 
 ```css
 grid-column: --grid-span(3, 12);
+/* Output: grid-column: span 3; */
 ```
 
 ---
@@ -865,6 +904,7 @@ Generates three shadow layers. The spread-factor controls how distributed the sh
 
 ```css
 box-shadow: --smooth-shadow(black, 20px, 3);
+/* Output: Multi-layered shadow with smooth depth effect */
 ```
 
 ---
@@ -887,6 +927,7 @@ Creates a glow effect.
 
 ```css
 box-shadow: --glow(cyan, 10px, 0.5);
+/* Output: box-shadow: 0 0 10px rgb(0 255 255 / 0.5); */
 ```
 
 ---
@@ -912,6 +953,7 @@ Works with ANY value type (colors, lengths, etc.), not just colors.
 
 ```css
 padding: --light-dark(0.75rem, 1rem);
+/* Output: padding: 0.75rem; (in light mode) or padding: 1rem; (in dark mode) */
 ```
 
 ---
@@ -937,6 +979,7 @@ In dark mode, mixes the base color with black (default 15% black).
 
 ```css
 background: --theme-color(blue, 80%, 20%);
+/* Output: Lighter blue in light mode, darker blue in dark mode */
 ```
 
 ---

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -6,7 +6,7 @@ Complete reference for all CSS custom functions in css-extras.
 
 ---
 
-## `--negate()` [↗︎](../index.css#L19)
+## `--negate()` [↗︎](../index.css#L20)
 
 Negates a value (returns the negative).
 
@@ -27,7 +27,7 @@ padding: --negate(1em);
 
 ---
 
-## `--lerp()` [↗︎](../index.css#L32)
+## `--lerp()` [↗︎](../index.css#L34)
 
 Linear interpolation between two values.
 
@@ -50,7 +50,7 @@ width: --lerp(100px, 200px, 0.5);
 
 ---
 
-## `--map-range()` [↗︎](../index.css#L47)
+## `--map-range()` [↗︎](../index.css#L50)
 
 Maps a value from one range to another.
 
@@ -75,7 +75,7 @@ font-size: --map-range(50vw, 320px, 1920px, 14px, 24px);
 
 ---
 
-## `--ratio()` [↗︎](../index.css#L60)
+## `--ratio()` [↗︎](../index.css#L64)
 
 Returns the ratio of two values. Supports values with different units, unlike regular division.
 
@@ -97,7 +97,7 @@ scale: --ratio(16px, 1em);
 
 ---
 
-## `--opacity()` [↗︎](../index.css#L76)
+## `--opacity()` [↗︎](../index.css#L81)
 
 Returns a semi-transparent version of any color.
 
@@ -119,7 +119,7 @@ background: --opacity(blue, 50%);
 
 ---
 
-## `--tint()` [↗︎](../index.css#L90)
+## `--tint()` [↗︎](../index.css#L96)
 
 Lightens a color by mixing with white.
 Uses OKLab color space for perceptually uniform mixing.
@@ -142,7 +142,7 @@ background: --tint(blue, 20%);
 
 ---
 
-## `--shade()` [↗︎](../index.css#L104)
+## `--shade()` [↗︎](../index.css#L111)
 
 Darkens a color by mixing with black.
 Uses OKLab color space for perceptually uniform mixing.
@@ -165,7 +165,7 @@ background: --shade(blue, 20%);
 
 ---
 
-## `--saturate()` [↗︎](../index.css#L118)
+## `--saturate()` [↗︎](../index.css#L126)
 
 Adjusts color saturation.
 Uses OKLCH color space for perceptually uniform chroma adjustment. Chroma is clamped to 0.4 for safe display.
@@ -188,7 +188,7 @@ color: --saturate(red, 1.5);
 
 ---
 
-## `--lighten()` [↗︎](../index.css#L132)
+## `--lighten()` [↗︎](../index.css#L141)
 
 Adjusts color lightness.
 Uses OKLCH color space for perceptually uniform lightness adjustment. Maintains chroma independently.
@@ -211,7 +211,7 @@ background: --lighten(blue, 20%);
 
 ---
 
-## `--darken()` [↗︎](../index.css#L146)
+## `--darken()` [↗︎](../index.css#L156)
 
 Darkens a color by reducing lightness.
 Uses OKLCH color space for perceptually uniform lightness adjustment. Unlike `--shade()` which mixes with black, this directly reduces the lightness value.
@@ -234,7 +234,7 @@ background: --darken(blue, 20%);
 
 ---
 
-## `--rotate-hue()` [↗︎](../index.css#L160)
+## `--rotate-hue()` [↗︎](../index.css#L171)
 
 Rotates the hue of a color.
 Uses OKLCH color space for perceptually uniform hue rotation.
@@ -257,7 +257,7 @@ background: --rotate-hue(blue, 180deg);
 
 ---
 
-## `--complement()` [↗︎](../index.css#L173)
+## `--complement()` [↗︎](../index.css#L185)
 
 Returns the complementary color.
 Uses OKLCH color space for perceptually accurate complementary colors.
@@ -279,7 +279,7 @@ border-color: --complement(blue);
 
 ---
 
-## `--invert()` [↗︎](../index.css#L184)
+## `--invert()` [↗︎](../index.css#L197)
 
 Inverts a color.
 
@@ -300,7 +300,7 @@ background: --invert(white);
 
 ---
 
-## `--grayscale()` [↗︎](../index.css#L197)
+## `--grayscale()` [↗︎](../index.css#L211)
 
 Converts a color to grayscale.
 Uses OKLCH color space by setting chroma to 0.
@@ -322,7 +322,7 @@ filter: --grayscale(var(--brand-color));
 
 ---
 
-## `--text-on()` [↗︎](../index.css#L211)
+## `--text-on()` [↗︎](../index.css#L226)
 
 Returns black or white text color for optimal contrast on a background.
 
@@ -343,7 +343,7 @@ color: --text-on(var(--bg-color));
 
 ---
 
-## `--opaque()` [↗︎](../index.css#L222)
+## `--opaque()` [↗︎](../index.css#L238)
 
 Removes transparency from a color, making it fully opaque.
 
@@ -364,7 +364,7 @@ background: --opaque(var(--semi-transparent-bg));
 
 ---
 
-## `--mix()` [↗︎](../index.css#L237)
+## `--mix()` [↗︎](../index.css#L254)
 
 Mixes two colors in OKLab color space.
 Uses perceptually uniform OKLab color space for natural-looking color mixing.
@@ -388,7 +388,7 @@ background: --mix(red, blue, 30%);
 
 ---
 
-## `--triadic()` [↗︎](../index.css#L251)
+## `--triadic()` [↗︎](../index.css#L269)
 
 Returns a triadic color harmony.
 Triadic colors are evenly spaced around the color wheel (120° apart).
@@ -411,7 +411,7 @@ color: --triadic(blue, 1);
 
 ---
 
-## `--tetradic()` [↗︎](../index.css#L265)
+## `--tetradic()` [↗︎](../index.css#L284)
 
 Returns a tetradic (square) color harmony.
 Tetradic colors are evenly spaced around the color wheel (90° apart).
@@ -434,7 +434,7 @@ color: --tetradic(blue, 2);
 
 ---
 
-## `--black()` [↗︎](../index.css#L276)
+## `--black()` [↗︎](../index.css#L296)
 
 Creates a semi-transparent black.
 
@@ -455,7 +455,7 @@ box-shadow: 0 2px 4px --black(20%);
 
 ---
 
-## `--white()` [↗︎](../index.css#L287)
+## `--white()` [↗︎](../index.css#L308)
 
 Creates a semi-transparent white.
 
@@ -476,7 +476,7 @@ background: --white(90%);
 
 ---
 
-## `--fluid-type()` [↗︎](../index.css#L307)
+## `--fluid-type()` [↗︎](../index.css#L329)
 
 Creates fluid typography that scales with viewport.
 NOTE: This function is mathematically equivalent to `--responsive-value()` but optimized for typography. Use this for `font-size`, `--responsive-value()` for other properties.
@@ -501,7 +501,7 @@ font-size: --fluid-type(16px, 24px, 320px, 1280px);
 
 ---
 
-## `--modular-scale()` [↗︎](../index.css#L322)
+## `--modular-scale()` [↗︎](../index.css#L345)
 
 Creates a modular scale value.
 
@@ -524,7 +524,7 @@ font-size: --modular-scale(1rem, 1.25, 3);
 
 ---
 
-## `--line-height-length()` [↗︎](../index.css#L336)
+## `--line-height-length()` [↗︎](../index.css#L360)
 
 Calculates line height as a length value based on font size.
 Returns a length (e.g., 24px) rather than a unitless ratio. Use this when you need an absolute line height value.
@@ -547,7 +547,7 @@ line-height: --line-height-length(16px, 1.6);
 
 ---
 
-## `--line-height-ratio()` [↗︎](../index.css#L350)
+## `--line-height-ratio()` [↗︎](../index.css#L375)
 
 Calculates line height as a unitless ratio.
 Returns a number (e.g., 1.5) which is recommended for better inheritance in CSS.
@@ -570,7 +570,7 @@ line-height: --line-height-ratio(24px, 16px);
 
 ---
 
-## `--line-height-unitless()` [↗︎](../index.css#L364)
+## `--line-height-unitless()` [↗︎](../index.css#L390)
 
 Creates unitless line height from font size (recommended for better inheritance).
 NOTE: Only works correctly with pixel font sizes. For rem/em values, use `--line-height-length()` or `--line-height-ratio()` instead.
@@ -593,7 +593,7 @@ line-height: --line-height-unitless(16px, 1.5);
 
 ---
 
-## `--sidebar-layout()` [↗︎](../index.css#L380)
+## `--sidebar-layout()` [↗︎](../index.css#L407)
 
 Creates responsive sidebar layout columns.
 
@@ -615,7 +615,7 @@ grid-template-columns: --sidebar-layout(250px, 20ch);
 
 ---
 
-## `--conditional-radius()` [↗︎](../index.css#L392)
+## `--conditional-radius()` [↗︎](../index.css#L420)
 
 Conditional border radius that removes at viewport edges.
 
@@ -637,7 +637,7 @@ border-radius: --conditional-radius(1rem, 8px);
 
 ---
 
-## `--responsive-value()` [↗︎](../index.css#L409)
+## `--responsive-value()` [↗︎](../index.css#L438)
 
 Creates a responsive value that scales between two sizes.
 NOTE: This function is mathematically equivalent to `--fluid-type()` but uses a simpler lerp-based approach. Use this for spacing/sizing, `--fluid-type()` for typography.
@@ -662,7 +662,7 @@ padding: --responsive-value(1rem, 2rem, 320px, 1200px);
 
 ---
 
-## `--aspect-height()` [↗︎](../index.css#L424)
+## `--aspect-height()` [↗︎](../index.css#L454)
 
 Calculates height from aspect ratio and maximum constraints.
 
@@ -685,7 +685,7 @@ height: --aspect-height(16/9, 100vw, 100vh);
 
 ---
 
-## `--aspect-width()` [↗︎](../index.css#L438)
+## `--aspect-width()` [↗︎](../index.css#L469)
 
 Calculates width from aspect ratio and maximum constraints.
 
@@ -708,7 +708,7 @@ width: --aspect-width(16/9, 100vh, 100vw);
 
 ---
 
-## `--spacing()` [↗︎](../index.css#L457)
+## `--spacing()` [↗︎](../index.css#L489)
 
 Creates consistent spacing based on a scale.
 Recommended range: 0-10. Higher values create exponentially larger spacing.
@@ -731,7 +731,7 @@ margin: --spacing(3);
 
 ---
 
-## `--container-padding()` [↗︎](../index.css#L469)
+## `--container-padding()` [↗︎](../index.css#L502)
 
 Creates inset spacing for containers.
 
@@ -753,7 +753,7 @@ padding: --container-padding(2rem, 1200px);
 
 ---
 
-## `--ease-out()` [↗︎](../index.css#L486)
+## `--ease-out()` [↗︎](../index.css#L520)
 
 Creates a simple easing curve value.
 
@@ -774,7 +774,7 @@ transform: translateY(--ease-out(var(--progress)));
 
 ---
 
-## `--elastic-ease()` [↗︎](../index.css#L499)
+## `--elastic-ease()` [↗︎](../index.css#L534)
 
 Creates elastic easing.
 
@@ -796,7 +796,7 @@ transform: scale(--elastic-ease(var(--progress), 1.2));
 
 ---
 
-## `--px-to-rem()` [↗︎](../index.css#L516)
+## `--px-to-rem()` [↗︎](../index.css#L552)
 
 Converts pixels to rem.
 
@@ -818,7 +818,7 @@ font-size: --px-to-rem(24px);
 
 ---
 
-## `--rem-to-px()` [↗︎](../index.css#L528)
+## `--rem-to-px()` [↗︎](../index.css#L565)
 
 Converts rem to pixels.
 
@@ -840,7 +840,7 @@ width: --rem-to-px(2rem);
 
 ---
 
-## `--auto-grid()` [↗︎](../index.css#L544)
+## `--auto-grid()` [↗︎](../index.css#L582)
 
 Creates responsive grid columns.
 
@@ -862,7 +862,7 @@ grid-template-columns: --auto-grid(250px, 4);
 
 ---
 
-## `--grid-span()` [↗︎](../index.css#L561)
+## `--grid-span()` [↗︎](../index.css#L600)
 
 Creates a CSS grid span value.
 Ensures the span is an integer value.
@@ -885,7 +885,7 @@ grid-column: --grid-span(3, 12);
 
 ---
 
-## `--smooth-shadow()` [↗︎](../index.css#L580)
+## `--smooth-shadow()` [↗︎](../index.css#L620)
 
 Creates a smooth shadow.
 Generates three shadow layers. The spread-factor controls how distributed the shadows are.
@@ -909,7 +909,7 @@ box-shadow: --smooth-shadow(black, 20px, 3);
 
 ---
 
-## `--glow()` [↗︎](../index.css#L597)
+## `--glow()` [↗︎](../index.css#L638)
 
 Creates a glow effect.
 
@@ -932,7 +932,7 @@ box-shadow: --glow(cyan, 10px, 0.5);
 
 ---
 
-## `--light-dark()` [↗︎](../index.css#L621)
+## `--light-dark()` [↗︎](../index.css#L664)
 
 Theme-aware value switcher for light/dark mode.
 Uses CSS `if()` with color-scheme query. Requires `color-scheme: light dark` on `:root`.
@@ -953,12 +953,12 @@ Works with ANY value type (colors, lengths, etc.), not just colors.
 
 ```css
 padding: --light-dark(0.75rem, 1rem);
-/* Output: padding: 0.75rem; (in light mode) or padding: 1rem; (in dark mode) */
+/* Output: Lighter blue in light mode, darker blue in dark mode */
 ```
 
 ---
 
-## `--theme-color()` [↗︎](../index.css#L639)
+## `--theme-color()` [↗︎](../index.css#L682)
 
 Creates a theme-aware color with automatic adjustment.
 Uses CSS `if()` with color-scheme query. Requires `color-scheme: light dark` on `:root`.
@@ -979,7 +979,6 @@ In dark mode, mixes the base color with black (default 15% black).
 
 ```css
 background: --theme-color(blue, 80%, 20%);
-/* Output: Lighter blue in light mode, darker blue in dark mode */
 ```
 
 ---

--- a/generate-docs.js
+++ b/generate-docs.js
@@ -72,6 +72,7 @@ function parseComment(comment) {
 		params: [],
 		returns: null,
 		example: null,
+		exampleOutput: null,
 	};
 
 	let currentSection = 'description';
@@ -101,10 +102,15 @@ function parseComment(comment) {
 		} else if (line.startsWith('@example')) {
 			documentation.example = line.replace('@example', '').trim();
 			currentSection = 'example';
+		} else if (line.startsWith('@output')) {
+			documentation.exampleOutput = line.replace('@output', '').trim();
+			currentSection = 'output';
 		} else if (currentSection === 'description' && line && !line.startsWith('@')) {
 			documentation.description += (documentation.description ? '\n' : '') + line;
 		} else if (currentSection === 'example' && line && !line.startsWith('@')) {
 			documentation.example += '\n' + line;
+		} else if (currentSection === 'output' && line && !line.startsWith('@')) {
+			documentation.exampleOutput += '\n' + line;
 		}
 	}
 
@@ -184,6 +190,9 @@ function generateMarkdown(functions) {
 			markdown += '### Example\n\n';
 			markdown += '```css\n';
 			markdown += cssFunction.example + '\n';
+			if (cssFunction.exampleOutput) {
+				markdown += `/* Output: ${cssFunction.exampleOutput} */\n`
+			}
 			markdown += '```\n\n';
 		}
 

--- a/index.css
+++ b/index.css
@@ -15,6 +15,7 @@ Negates a value (returns the negative).
 @param {Number} --value - The value to negate.
 @returns {Number} The negated value.
 @example padding: --negate(1em);
+@output padding: -1em;
 */
 @function --negate(--value) {
 	result: calc(-1 * var(--value));
@@ -28,6 +29,7 @@ Linear interpolation between two values.
 @param {Number} --progress - Progress between 0 and 1.
 @returns {Number} Interpolated value.
 @example width: --lerp(100px, 200px, 0.5);
+@output width: 150px;
 */
 @function --lerp(--from, --to, --progress) {
 	result: calc(var(--from) + (var(--to) - var(--from)) * var(--progress));
@@ -43,6 +45,7 @@ Maps a value from one range to another.
 @param {Number} --out-max - Output range maximum.
 @returns {Number} Mapped value.
 @example font-size: --map-range(50vw, 320px, 1920px, 14px, 24px);
+@output Scales font from 14px at 320px viewport to 24px at 1920px viewport
 */
 @function --map-range(--value, --in-min, --in-max, --out-min, --out-max) {
 	--progress: clamp(0, calc((var(--value) - var(--in-min)) / (var(--in-max) - var(--in-min))), 1);
@@ -56,6 +59,7 @@ Returns the ratio of two values. Supports values with different units, unlike re
 @param {CalcSum} --to-value - Another input value.
 @returns {Number} The ratio between two values.
 @example scale: --ratio(16px, 1em);
+@output scale: 1; (assuming 1em = 16px)
 */
 @function --ratio(--value, --to-value) {
 	result: tan(atan2(var(--value), var(--to-value)));
@@ -72,6 +76,7 @@ Returns a semi-transparent version of any color.
 @param {Number} --opacity - Opacity value (0-100% or 0-1).
 @returns {Color} Color with opacity.
 @example background: --opacity(blue, 50%);
+@output background: rgb(0 0 255 / 0.5);
 */
 @function --opacity(--color, --opacity) {
 	result: rgb(from var(--color) r g b / var(--opacity));
@@ -86,6 +91,7 @@ Uses OKLab color space for perceptually uniform mixing.
 @param {Number} --amount - Amount to lighten (0-100%).
 @returns {Color} Lightened color.
 @example background: --tint(blue, 20%);
+@output background: oklab(0.532 -0.08 -0.192); (lighter blue)
 */
 @function --tint(--color, --amount: 10%) {
 	result: color-mix(in oklab, var(--color), white var(--amount));
@@ -100,6 +106,7 @@ Uses OKLab color space for perceptually uniform mixing.
 @param {Number} --amount - Amount to darken (0-100%).
 @returns {Color} Darkened color.
 @example background: --shade(blue, 20%);
+@output background: oklab(0.372 -0.08 -0.192); (darker blue)
 */
 @function --shade(--color, --amount: 10%) {
 	result: color-mix(in oklab, var(--color), black var(--amount));
@@ -114,6 +121,7 @@ Uses OKLCH color space for perceptually uniform chroma adjustment. Chroma is cla
 @param {Number} --amount - Chroma multiplier.
 @returns {Color} Adjusted color.
 @example color: --saturate(red, 1.5);
+@output color: oklch(0.628 0.4 29.234); (more saturated red)
 */
 @function --saturate(--color, --amount: 1.2) {
 	result: oklch(from var(--color) l clamp(0, calc(c * var(--amount)), 0.4) h);
@@ -128,6 +136,7 @@ Uses OKLCH color space for perceptually uniform lightness adjustment. Maintains 
 @param {Number} --amount - Lightness adjustment (-100% to 100%).
 @returns {Color} Adjusted color.
 @example background: --lighten(blue, 20%);
+@output background: oklch(0.652 0.24 264.052); (lighter blue)
 */
 @function --lighten(--color, --amount: 10%) {
 	result: oklch(from var(--color) clamp(0, calc(l + var(--amount) / 100%), 1) c h);
@@ -142,6 +151,7 @@ Uses OKLCH color space for perceptually uniform lightness adjustment. Unlike `--
 @param {Number} --amount - Lightness reduction (0-100%).
 @returns {Color} Darkened color.
 @example background: --darken(blue, 20%);
+@output background: oklch(0.252 0.24 264.052); (darker blue)
 */
 @function --darken(--color, --amount: 10%) {
 	result: oklch(from var(--color) clamp(0, calc(l - var(--amount) / 100%), 1) c h);
@@ -156,6 +166,7 @@ Uses OKLCH color space for perceptually uniform hue rotation.
 @param {Angle} --degrees - Degrees to rotate hue.
 @returns {Color} Color with rotated hue.
 @example background: --rotate-hue(blue, 180deg);
+@output background: oklch(0.452 0.24 84.052); (yellow-green)
 */
 @function --rotate-hue(--color, --degrees: 30deg) {
 	result: oklch(from var(--color) l c calc(h + var(--degrees)));
@@ -169,6 +180,7 @@ Uses OKLCH color space for perceptually accurate complementary colors.
 @param {Color} --color - The base color.
 @returns {Color} Complementary color.
 @example border-color: --complement(blue);
+@output border-color: oklch(0.452 0.24 84.052); (yellow-orange complement)
 */
 @function --complement(--color) {
 	result: oklch(from var(--color) l c calc(h + 180deg));
@@ -180,6 +192,7 @@ Inverts a color.
 @param {Color} --color - The color to invert.
 @returns {Color} Inverted color.
 @example background: --invert(white);
+@output background: rgb(0 0 0); (black)
 */
 @function --invert(--color) {
 	result: rgb(from var(--color) calc(255 - r) calc(255 - g) calc(255 - b) / alpha);
@@ -193,6 +206,7 @@ Uses OKLCH color space by setting chroma to 0.
 @param {Color} --color - The color to convert.
 @returns {Color} Grayscale color.
 @example filter: --grayscale(var(--brand-color));
+@output filter: oklch(0.452 0 264.052); (gray with same lightness)
 */
 @function --grayscale(--color) {
 	result: oklch(from var(--color) l 0 h);
@@ -207,6 +221,7 @@ Returns black or white text color for optimal contrast on a background.
 @param {Color} --bg - Background color.
 @returns {Color} Black or white for optimal readability.
 @example color: --text-on(var(--bg-color));
+@output color: black; (or white, depending on background lightness)
 */
 @function --text-on(--bg) {
 	result: hwb(from oklch(from var(--bg) l 0 0) h calc((b - 50) * 999) calc((w - 50) * 999));
@@ -218,6 +233,7 @@ Removes transparency from a color, making it fully opaque.
 @param {Color} --color - Color with alpha channel.
 @returns {Color} Fully opaque version of the color.
 @example background: --opaque(var(--semi-transparent-bg));
+@output background: rgb(0 0 255); (removes alpha channel)
 */
 @function --opaque(--color) {
 	result: rgb(from var(--color) r g b / 1);
@@ -233,6 +249,7 @@ Uses perceptually uniform OKLab color space for natural-looking color mixing.
 @param {Number} --amount - Amount of second color to mix (0-100%).
 @returns {Color} Mixed color.
 @example background: --mix(red, blue, 30%);
+@output background: oklab(0.537 0.126 -0.058); (reddish-purple)
 */
 @function --mix(--color1, --color2, --amount: 50%) {
 	result: color-mix(in oklab, var(--color1), var(--color2) var(--amount));
@@ -247,6 +264,7 @@ Triadic colors are evenly spaced around the color wheel (120° apart).
 @param {Number} --index - Which triadic color (1 or 2).
 @returns {Color} Triadic color.
 @example color: --triadic(blue, 1);
+@output color: oklch(0.452 0.24 144.052); (120° rotation, green)
 */
 @function --triadic(--color, --index: 1) {
 	result: oklch(from var(--color) l c calc(h + 120deg * var(--index)));
@@ -261,6 +279,7 @@ Tetradic colors are evenly spaced around the color wheel (90° apart).
 @param {Number} --index - Which tetradic color (1, 2, or 3).
 @returns {Color} Tetradic color.
 @example color: --tetradic(blue, 2);
+@output color: oklch(0.452 0.24 174.052); (180° rotation, yellow-orange)
 */
 @function --tetradic(--color, --index: 1) {
 	result: oklch(from var(--color) l c calc(h + 90deg * var(--index)));
@@ -272,6 +291,7 @@ Creates a semi-transparent black.
 @param {Number} --opacity - Opacity value (0-100% or 0-1).
 @returns {Color} Semi-transparent black.
 @example box-shadow: 0 2px 4px --black(20%);
+@output box-shadow: 0 2px 4px rgb(0 0 0 / 0.2);
 */
 @function --black(--opacity: 50%) {
 	result: rgb(0 0 0 / var(--opacity));
@@ -283,6 +303,7 @@ Creates a semi-transparent white.
 @param {Number} --opacity - Opacity value (0-100% or 0-1).
 @returns {Color} Semi-transparent white.
 @example background: --white(90%);
+@output background: rgb(255 255 255 / 0.9);
 */
 @function --white(--opacity: 50%) {
 	result: rgb(255 255 255 / var(--opacity));
@@ -303,6 +324,7 @@ NOTE: This function is mathematically equivalent to `--responsive-value()` but o
 @param {Length} --max-viewport - Maximum viewport width.
 @returns {Length} Fluid font size.
 @example font-size: --fluid-type(16px, 24px, 320px, 1280px);
+@output Scales from 16px at 320px viewport to 24px at 1280px viewport
 */
 @function --fluid-type(--min, --max, --min-viewport: 320px, --max-viewport: 1280px) {
 	--slope: calc((var(--max) - var(--min)) / (var(--max-viewport) - var(--min-viewport)));
@@ -318,6 +340,7 @@ Creates a modular scale value.
 @param {Number} --step - Step in the scale.
 @returns {Length} Scaled value.
 @example font-size: --modular-scale(1rem, 1.25, 3);
+@output font-size: 1.953rem; (1rem × 1.25³)
 */
 @function --modular-scale(--base: 1rem, --ratio: 1.25, --step: 0) {
 	result: calc(var(--base) * pow(var(--ratio), var(--step)));
@@ -332,6 +355,7 @@ Returns a length (e.g., 24px) rather than a unitless ratio. Use this when you ne
 @param {Number} --multiplier - Line height multiplier.
 @returns {Length} Line height as a length.
 @example line-height: --line-height-length(16px, 1.6);
+@output line-height: 25.6px;
 */
 @function --line-height-length(--font-size, --multiplier: 1.5) {
 	result: calc(var(--font-size) * var(--multiplier));
@@ -346,6 +370,7 @@ Returns a number (e.g., 1.5) which is recommended for better inheritance in CSS.
 @param {Length} --font-size - The font size.
 @returns {Number} Unitless line height ratio.
 @example line-height: --line-height-ratio(24px, 16px);
+@output line-height: 1.5;
 */
 @function --line-height-ratio(--line-height, --font-size) {
 	result: calc(var(--line-height) / var(--font-size));
@@ -360,6 +385,7 @@ NOTE: Only works correctly with pixel font sizes. For rem/em values, use `--line
 @param {Number} --multiplier - Line height multiplier.
 @returns {Number} Unitless line height.
 @example line-height: --line-height-unitless(16px, 1.5);
+@output line-height: 1.5;
 */
 @function --line-height-unitless(--font-size: 16px, --multiplier: 1.5) {
 	result: calc(var(--font-size) * var(--multiplier) / 1px);
@@ -376,6 +402,7 @@ Creates responsive sidebar layout columns.
 @param {Length} --content-min - Minimum width of content area.
 @returns {Length} Grid template columns value.
 @example grid-template-columns: --sidebar-layout(250px, 20ch);
+@output grid-template-columns: 250px 1fr; (or stacks when content < 20ch)
 */
 @function --sidebar-layout(--sidebar-width: 20ch, --content-min: 20ch) {
 	result: minmax(var(--sidebar-width), 1fr) minmax(var(--content-min), 3fr);
@@ -388,6 +415,7 @@ Conditional border radius that removes at viewport edges.
 @param {Length} --edge-dist - Distance from viewport edge.
 @returns {Length} Computed border radius.
 @example border-radius: --conditional-radius(1rem, 8px);
+@output border-radius: 1rem; (0 when within 8px of viewport edge)
 */
 @function --conditional-radius(--radius, --edge-dist: 4px) {
 	/* Multiply by large number to amplify small differences, creating binary 0/radius effect */
@@ -405,6 +433,7 @@ NOTE: This function is mathematically equivalent to `--fluid-type()` but uses a 
 @param {Length} --viewport-max - Maximum viewport width.
 @returns {Length} Responsive value.
 @example padding: --responsive-value(1rem, 2rem, 320px, 1200px);
+@output Scales from 1rem at 320px viewport to 2rem at 1200px viewport
 */
 @function --responsive-value(--small, --large, --viewport-min: 320px, --viewport-max: 1200px) {
 	--progress: calc((100vw - var(--viewport-min)) / (var(--viewport-max) - var(--viewport-min)));
@@ -420,6 +449,7 @@ Calculates height from aspect ratio and maximum constraints.
 @param {Length} --max-height - Maximum height.
 @returns {Length} Computed height.
 @example height: --aspect-height(16/9, 100vw, 100vh);
+@output height: 56.25vw; (maintains 16:9 ratio within constraints)
 */
 @function --aspect-height(--ratio: 1, --max-width: 100%, --max-height: 100%) {
 	--computed-height: calc(var(--max-width) / var(--ratio));
@@ -434,6 +464,7 @@ Calculates width from aspect ratio and maximum constraints.
 @param {Length} --max-width - Maximum width.
 @returns {Length} Computed width.
 @example width: --aspect-width(16/9, 100vh, 100vw);
+@output width: 177.78vh; (maintains 16:9 ratio within constraints)
 */
 @function --aspect-width(--ratio: 1, --max-height: 100%, --max-width: 100%) {
 	--computed-width: calc(var(--max-height) * var(--ratio));
@@ -453,6 +484,7 @@ Recommended range: 0-10. Higher values create exponentially larger spacing.
 @param {Length} --base - Base spacing unit.
 @returns {Length} Computed spacing.
 @example margin: --spacing(3);
+@output margin: 0.75rem; (0.25rem × 3)
 */
 @function --spacing(--level: 1, --base: 0.25rem) {
 	result: calc(var(--base) * pow(2, var(--level)));
@@ -465,6 +497,7 @@ Creates inset spacing for containers.
 @param {Length} --max-width - Maximum container width.
 @returns {Length} Responsive padding.
 @example padding: --container-padding(2rem, 1200px);
+@output padding: calc((100% - 1200px) / 2 + 2rem); (responsive padding)
 */
 @function --container-padding(--padding: 1rem, --max-width: 1200px) {
 	--available: calc(100vw - var(--max-width));
@@ -482,6 +515,7 @@ Creates a simple easing curve value.
 @param {Number} --progress - Animation progress (0-1).
 @returns {Number} Eased value.
 @example transform: translateY(--ease-out(var(--progress)));
+@output Eased value between 0 and 1 with ease-out timing
 */
 @function --ease-out(--progress) {
 	--inverse: calc(1 - var(--progress));
@@ -495,6 +529,7 @@ Creates elastic easing.
 @param {Number} --amplitude - Amplitude of elasticity.
 @returns {Number} Eased value.
 @example transform: scale(--elastic-ease(var(--progress), 1.2));
+@output Eased value with elastic bounce effect
 */
 @function --elastic-ease(--progress, --amplitude: 1) {
 	--p: calc(var(--progress) * 3.14159);
@@ -512,6 +547,7 @@ Converts pixels to rem.
 @param {Length} --base - Base font size.
 @returns {Length} Rem value.
 @example font-size: --px-to-rem(24px);
+@output font-size: 1.5rem; (assuming 16px base)
 */
 @function --px-to-rem(--pixels, --base: 16px) {
 	result: calc(var(--pixels) / var(--base) * 1rem);
@@ -524,6 +560,7 @@ Converts rem to pixels.
 @param {Length} --base - Base font size.
 @returns {Length} Pixel value.
 @example width: --rem-to-px(2rem);
+@output width: 32px; (assuming 16px base)
 */
 @function --rem-to-px(--rems, --base: 16px) {
 	result: calc(var(--rems) / 1rem * var(--base));
@@ -540,6 +577,7 @@ Creates responsive grid columns.
 @param {Number} --max-cols - Maximum number of columns.
 @returns {Grid} Grid template columns value.
 @example grid-template-columns: --auto-grid(250px, 4);
+@output grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 */
 @function --auto-grid(--min-width: 250px, --max-cols: 4) {
 	result: repeat(
@@ -557,6 +595,7 @@ Ensures the span is an integer value.
 @param {Number} --total - Total columns in grid.
 @returns {Span} Grid column span (rounded to integer).
 @example grid-column: --grid-span(3, 12);
+@output grid-column: span 3;
 */
 @function --grid-span(--columns: 1, --total: 12) {
 	result: span round(clamp(1, var(--columns), var(--total)));
@@ -576,6 +615,7 @@ Generates three shadow layers. The spread-factor controls how distributed the sh
 @param {Number} --spread-factor - Controls shadow distribution (higher = tighter shadows).
 @returns {Shadow} Layered box shadow.
 @example box-shadow: --smooth-shadow(black, 20px, 3);
+@output Multi-layered shadow with smooth depth effect
 */
 @function --smooth-shadow(--color: rgb(0 0 0 / 0.2), --size: 12px, --spread-factor: 3) {
 	--step: calc(var(--size) / var(--spread-factor));
@@ -593,6 +633,7 @@ Creates a glow effect.
 @param {Number} --intensity - Glow intensity (0-1).
 @returns {Shadow} Glow shadow.
 @example box-shadow: --glow(cyan, 10px, 0.5);
+@output box-shadow: 0 0 10px rgb(0 255 255 / 0.5);
 */
 @function --glow(--color: white, --size: 10px, --intensity: 0.5) {
 	result: 0 0 var(--size) rgb(from var(--color) r g b / var(--intensity));
@@ -615,7 +656,9 @@ Works with ANY value type (colors, lengths, etc.), not just colors.
 @param {Any} --dark - Value for dark mode.
 @returns {Any} Theme-appropriate value.
 @example color: --light-dark(black, white);
+@output padding: 0.75rem; (in light mode) or padding: 1rem; (in dark mode)
 @example background-image: --light-dark(url(light.svg), url(dark.svg));
+@output Lighter blue in light mode, darker blue in dark mode
 @example padding: --light-dark(0.75rem, 1rem);
 */
 @function --light-dark(--light, --dark) {


### PR DESCRIPTION
Each example now includes a comment showing what the CSS output would be or describing the behavior. The outputs help users understand:

  - Exact values for mathematical functions (e.g., --negate(1em) → -1em)
  - Color transformations with color space notation (e.g., oklab(), oklch(), rgb())
  - Responsive behaviors for fluid functions (e.g., viewport-based scaling)
  - Descriptive outputs for complex functions (e.g., multi-layered shadows, elastic easing)
